### PR TITLE
Allow dependency gems to use latest version

### DIFF
--- a/capify-ec2.gemspec
+++ b/capify-ec2.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_dependency('activesupport', '>= 3.0.0')
-  s.add_dependency('fog', '=0.10.0')
-  s.add_dependency('colored', '=1.2')
+  s.add_dependency('fog', '>=0.10.0')
+  s.add_dependency('colored', '>=1.2')
 end


### PR DESCRIPTION
Colored and fog gems are hardcoded to a specific version.  
Propose to change the dependency for fog and colored gems to be >= instead of = to the hardcoded version.
