### PR TITLE
A few optimizations

### DIFF
--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -9,8 +9,16 @@ class CapifyEc2
   attr_accessor :load_balancer, :instances
   SLEEP_COUNT = 5
   
-  def initialize(config_path = "config/ec2.yml")
-    @ec2_config = YAML.load(File.new(config_path))
+  def initialize(ec2_config = "config/ec2.yml")
+    case ec2_config
+    when Hash
+      @ec2_config = ec2_config
+    when String
+      @ec2_config = YAML.load_file ec2_config
+    else
+      raise ArgumentError, "Invalid ec2_config: #{ec2_config.inspect}"
+    end
+
     regions = determine_regions()
     
     @instances = []

--- a/lib/capify-ec2/capistrano.rb
+++ b/lib/capify-ec2/capistrano.rb
@@ -3,7 +3,7 @@ require 'colored'
 
 Capistrano::Configuration.instance(:must_exist).load do  
   def capify_ec2
-    @capify_ec2 ||= CapifyEc2.new
+    @capify_ec2 ||= CapifyEc2.new(fetch(:ec2_config, 'config/ec2.yml'))
   end
 
   namespace :ec2 do


### PR DESCRIPTION
A Hash or different config path can be passed. It makes it easier to hack it together with a multi-env deploy.

I use it like that:

``` ruby
STAGE = ENV['STAGE']
set :ec2_config, YAML.load_file(File.expand_path("../#{STAGE}/config.yml", __FILE__))
require 'capify-ec2/capistrano'

```
