### PR TITLE
Upgrading Fog from version 1.1.1 to 1.3.1 

### DIFF
--- a/capify-ec2.gemspec
+++ b/capify-ec2.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_dependency('fog', '=1.1.1')
+  s.add_dependency('fog', '=1.3.1')
   s.add_dependency('colored', '=1.2')
   s.add_dependency('capistrano')
 end


### PR DESCRIPTION
Fog v 1.3.1 has a dependency on an old multijson gem version which conflicts with the latest Goliath gem. 
