### PR TITLE
ArgumentError for define_role

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>capify-ec2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>com.aptana.ide.core.unifiedBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.aptana.ruby.core.rubynature</nature>
+		<nature>com.aptana.projects.webnature</nature>
+	</natures>
+</projectDescription>

--- a/lib/capify-ec2/capistrano.rb
+++ b/lib/capify-ec2/capistrano.rb
@@ -128,7 +128,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     end 
   end
 
-  def define_role(role, instance, variables)
+  def define_role(role, instance, variables={})
     options     = role[:options] || {}
     
     cap_options = options.inject({}) do |cap_options, (key, value)| 


### PR DESCRIPTION
Thank you for the wonderful GEM!

I update my gem to v1.3.4 from v1.3.1.
I have encountered an ArgumentError.when I call define_role via ec2_roles.

I simply patched this error with set default for "define_role"'s third argument.

Do you think this is OK?
