### PR TITLE
Fix ec2_role when role_name_or_hash is not a hash.

### DIFF
--- a/lib/capify-ec2/capistrano.rb
+++ b/lib/capify-ec2/capistrano.rb
@@ -78,7 +78,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   
   def ec2_role(role_name_or_hash)
     role      = role_name_or_hash.is_a?(Hash) ? role_name_or_hash : {:name => role_name_or_hash,:options => {}}
-    variables = role_name_or_hash[:variables] || {}
+    variables = role[:variables] || {}
         
     instances = capify_ec2.get_instances_by_role(role[:name])
 


### PR DESCRIPTION
I believe this is what the original author meant, when adding this functionality. Either I'm missing something or 1.3.5 has not worked with something as simple as 'ec2_roles :web' 

For me it failed with:

```
capistrano.rb:81:in `[]': can't convert Symbol into Integer (TypeError)
```
