### PR TITLE
Changed initialize to use aws_access_key_id and aws_access_secret_key me...

### DIFF
--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -59,8 +59,8 @@ class CapifyEc2
     if @ec2_config[:use_iam_profile]
       { :use_iam_profile       => true }
     else
-      { :aws_access_key_id     => @ec2_config[:aws_access_key_id], 
-        :aws_secret_access_key => @ec2_config[:aws_secret_access_key] }
+      { :aws_access_key_id     => aws_access_key_id,
+        :aws_secret_access_key => aws_secret_access_key }
     end
   end
   


### PR DESCRIPTION
The current 1.5.0-pre gem isn't pulling in configuration from anything except for ec2.yml.  This pull request fixes that.
