### PR TITLE
Make ec2:ssh use the ssh key if configured

### DIFF
--- a/lib/capify-ec2/capistrano.rb
+++ b/lib/capify-ec2/capistrano.rb
@@ -45,7 +45,11 @@ Capistrano::Configuration.instance(:must_exist).load do
 
         if instance and instance.contact_point then
           port = ssh_options[:port] || 22 
-          command = "ssh -p #{port} #{user}@#{instance.contact_point}"
+          key = ""
+          if !ssh_options[:keys].empty?
+            key = "-i #{ssh_options[:keys]}"
+          end
+          command = "ssh -p #{port} #{key} #{user}@#{instance.contact_point}"
           puts "Running `#{command}`"
           exec(command)
         else


### PR DESCRIPTION
Hi!  First off, thanks so much for this tool!

I typically don't program in Ruby, so I'm not sure if I'm doing everything the best way possible here, but I've made a few additions.  All of these are working here, but not knowing ruby or capistrano well, I haven't tested them in different circumstances, but I think they should be compatible.  If you have any questions / comments / change requests, I'm totally open!

This pull request add support for `Net::SSH`'s [ssh_options[:keys]](http://net-ssh.github.io/ssh/v1/chapter-2.html).
