### PR TITLE
Support for ssh_options[:keys] being an array or a string

### DIFF
--- a/lib/capify-ec2/capistrano.rb
+++ b/lib/capify-ec2/capistrano.rb
@@ -2,13 +2,13 @@ require File.join(File.dirname(__FILE__), '../capify-ec2')
 require 'colored'
 require 'pp'
 
-Capistrano::Configuration.instance(:must_exist).load do  
+Capistrano::Configuration.instance(:must_exist).load do
   def capify_ec2
     @capify_ec2 ||= CapifyEc2.new(fetch(:ec2_config, 'config/ec2.yml'), fetch(:stage, ''))
   end
 
   namespace :ec2 do
-    
+
     desc "Prints out all ec2 instances. index, name, instance_id, size, DNS/IP, region, tags"
     task :status do
       capify_ec2.display_instances
@@ -42,15 +42,18 @@ Capistrano::Configuration.instance(:must_exist).load do
       if "ec2:ssh" == server then
         server = variables[:logger].instance_variable_get("@options")[:actions][2]
       end
-      
+
       if server
         instance = numeric?(server) ? capify_ec2.desired_instances[server.to_i] : capify_ec2.get_instance_by_name(server)
 
         if instance and instance.contact_point then
-          port = ssh_options[:port] || 22 
+          port = ssh_options.fetch(:port, 22)
           key = ""
-          if !ssh_options[:keys].to_s.empty?
+          if ssh_options[:keys].is_a?(String) && !ssh_options[:keys].to_s.empty?
             key = "-i #{ssh_options[:keys]}"
+          end
+          if ssh_options[:keys].is_a?(Array) && ssh_options[:keys].length > 0
+            key = "-i #{ssh_options[:keys].first}"
           end
           command = "ssh -p #{port} #{key} #{user}@#{instance.contact_point}"
           puts "Running `#{command}`"
@@ -71,7 +74,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     after "deploy", "ec2:register_instance"
     after "deploy:rollback", "ec2:register_instance"
   end
-    
+
   desc "Deploy to servers one at a time."
   task :rolling_deploy do
     puts "[Capify-EC2] Performing rolling deployment..."
@@ -112,7 +115,7 @@ Capistrano::Configuration.instance(:must_exist).load do
           role a_role, server_dns, all_options[a_role][server_dns]
           is_load_balanced = true if all_options[a_role][server_dns][:load_balanced]
         end
-        
+
         puts "[Capify-EC2]"
         puts "[Capify-EC2] Beginning deployment to #{instance_dns_with_name_tag(server_dns)} with #{server_roles.count > 1 ? 'roles' : 'role'} '#{server_roles.join(', ')}'...".bold
 
@@ -124,7 +127,7 @@ Capistrano::Configuration.instance(:must_exist).load do
         top.deploy.default
 
         server_roles.each do |a_role|
-        
+
           # If healthcheck(s) are defined for this role, run them.
           if all_options[a_role][server_dns][:healthcheck]
             healthchecks_for_role = [ all_options[a_role][server_dns][:healthcheck] ].flatten
@@ -137,9 +140,9 @@ Capistrano::Configuration.instance(:must_exist).load do
               options[:timeout] = healthcheck_for_role[:timeout] ||= 60
 
               healthcheck = capify_ec2.instance_health_by_url( server_dns,
-                                                               healthcheck_for_role[:port], 
-                                                               healthcheck_for_role[:path], 
-                                                               healthcheck_for_role[:result], 
+                                                               healthcheck_for_role[:port],
+                                                               healthcheck_for_role[:path],
+                                                               healthcheck_for_role[:result],
                                                                options )
               if healthcheck
                 puts "[Capify-EC2] Healthcheck #{i+1} of #{healthchecks_for_role.size} for role '#{a_role}' successful.".green.bold
@@ -161,7 +164,7 @@ Capistrano::Configuration.instance(:must_exist).load do
             raise CapifyEC2RollingDeployError.new("ELB registration timeout exceeded", server_dns)
           end
         end
-   
+
         puts "[Capify-EC2] Deployment successful to #{instance_dns_with_name_tag(server_dns)}.".green.bold
         successful_deploys << server_dns
 
@@ -186,7 +189,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       exit 1
     else
       puts "[Capify-EC2]"
-      puts "[Capify-EC2] Rolling deployment completed.".green.bold  
+      puts "[Capify-EC2] Rolling deployment completed.".green.bold
 
       rolling_deploy_status(all_servers, successful_deploys, failed_deploys)
     end
@@ -196,11 +199,11 @@ Capistrano::Configuration.instance(:must_exist).load do
     puts "[Capify-EC2]"
     puts "[Capify-EC2]   Successful servers:"
     format_rolling_deploy_results( all_servers, successful_deploys )
-     
+
     puts "[Capify-EC2]"
     puts "[Capify-EC2]   Failed servers:"
     format_rolling_deploy_results( all_servers, failed_deploys )
-    
+
     puts "[Capify-EC2]"
     puts "[Capify-EC2]   Pending servers:"
     pending_deploys = (all_servers.keys - successful_deploys) - failed_deploys
@@ -209,10 +212,10 @@ Capistrano::Configuration.instance(:must_exist).load do
 
   def ec2_roles(*roles)
     server_name = variables[:logger].instance_variable_get("@options")[:actions].first unless variables[:logger].instance_variable_get("@options")[:actions][1].nil?
-    
+
     if !server_name.nil? && !server_name.empty?
       named_instance = capify_ec2.get_instance_by_name(server_name)
-  
+
       task named_instance.name.to_sym do
         remove_default_roles
         server_address = named_instance.contact_point
@@ -221,8 +224,8 @@ Capistrano::Configuration.instance(:must_exist).load do
           roles = named_instance.roles
         else
           roles = [named_instance.tags[ capify_ec2.ec2_config[:aws_roles_tag] ]].flatten
-        end    
-        
+        end
+
         roles.each do |role|
           define_role({:name => role, :options => {:on_no_matching_servers => :continue}}, named_instance)
         end
@@ -230,10 +233,10 @@ Capistrano::Configuration.instance(:must_exist).load do
     end
     roles.each {|role| ec2_role(role)}
   end
-  
+
   def ec2_role(role_name_or_hash)
     role = role_name_or_hash.is_a?(Hash) ? role_name_or_hash : {:name => role_name_or_hash, :options => {}, :variables => {}}
-        
+
     instances = capify_ec2.get_instances_by_role(role[:name])
     if role[:options] && role[:options].delete(:default)
       instances.each do |instance|
@@ -248,7 +251,7 @@ Capistrano::Configuration.instance(:must_exist).load do
 
     define_role_roles(role, instances)
     define_instance_roles(role, instances)
-  end  
+  end
 
   def define_regions(region, role)
     instances = []
@@ -279,29 +282,29 @@ Capistrano::Configuration.instance(:must_exist).load do
       instances.each do |instance|
         define_role(role, instance)
       end
-    end 
+    end
   end
 
   def define_role(role, instance)
     options     = role[:options] || {}
     variables   = role[:variables] || {}
 
-    cap_options = options.inject({}) do |cap_options, (key, value)| 
+    cap_options = options.inject({}) do |cap_options, (key, value)|
       cap_options[key] = true if value.to_s == instance.name
       cap_options
-    end 
+    end
 
     ec2_options = instance.tags[capify_ec2.ec2_config[:aws_options_tag]] || ""
     ec2_options.split(%r{,\s*}).compact.each { |ec2_option|  cap_options[ec2_option.to_sym] = true }
 
-    variables.each do |key, value| 
+    variables.each do |key, value|
       set key, value
       cap_options[key] = value unless cap_options.has_key? key
     end
 
     role role[:name].to_sym, instance.contact_point, cap_options
   end
-  
+
   def numeric?(object)
     true if Float(object) rescue false
   end
@@ -315,9 +318,9 @@ Capistrano::Configuration.instance(:must_exist).load do
         "#{singular}s"
     end
   end
-  
-  def remove_default_roles	 	
+
+  def remove_default_roles
     roles.reject! { true }
   end
-  
+
 end

--- a/readme.md
+++ b/readme.md
@@ -557,7 +557,7 @@ Using the `cap ec2:ssh` command, you can quickly connect to a specific instance,
 cap ec2:ssh 1
 ```
 
-will attempt to connect to instance number 1 (as shown in `ec2:status`), using the public DNS address provided by AWS.
+will attempt to connect to instance number 1 (as shown in `ec2:status`), using the public DNS address provided by AWS and the first SSH key listed in ` ssh_options[:keys] `.
 
 
 
@@ -649,25 +649,25 @@ In our examples, imagine that you have three servers on EC2 named and tagged as 
     <td>'Name' Tag</td>
     <td>'Roles' Tag</td>
     <td>'Options' Tag</td>
-		<td>'Stages' Tag</td>
+    <td>'Stages' Tag</td>
   </tr>
   <tr>
     <td>server-1</td>
     <td>web</td>
     <td>cron,resque</td>
-		<td>production</td>
+    <td>production</td>
   </tr>
   <tr>
     <td>server-2</td>
     <td>db</td>
     <td></td>
-		<td>production</td>
+    <td>production</td>
   </tr>
   <tr>
     <td>server-3</td>
     <td>web,db</td>
     <td></td>
-		<td>staging</td>
+    <td>staging</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Thank you for this tool, `cap ec2:ssh` has saved me from a number of unreliable and ever changing bash aliases.

This change add support for arrays in `ssh_options[:keys]` by checking the type of `:keys` and acting accordingly. By default Capistrano treats `ssh_options[:keys]` as an array from to its reliance on Net::SSH.

Thanks again.
