### PR TITLE
Use instance's ID rather than empty string when instance has no name tag

### DIFF
--- a/lib/capify-ec2/server.rb
+++ b/lib/capify-ec2/server.rb
@@ -10,7 +10,7 @@ module Fog
         end
         
         def name
-          tags["Name"] || ""
+          tags["Name"] || id
         end
       end
     end


### PR DESCRIPTION
If you use an empty string as the instance's name when it has no tagged name, you get a nasty stack trace if you try to run some cap tasks, because some code tries to do `instance.name.to_sym`, which won't work on an emptry string.

This PR changes it to report the instance's ID instead of the empty string if the instance is not tagged with a name.
