### PR TITLE
Fix for roles chaining

### DIFF
--- a/lib/capify-ec2/capistrano.rb
+++ b/lib/capify-ec2/capistrano.rb
@@ -220,7 +220,6 @@ Capistrano::Configuration.instance(:must_exist).load do
       named_instance = capify_ec2.get_instance_by_name(server_name)
 
       task named_instance.name.to_sym do
-        remove_default_roles
         server_address = named_instance.contact_point
 
         if named_instance.respond_to?(:roles)
@@ -263,7 +262,6 @@ Capistrano::Configuration.instance(:must_exist).load do
       region_instances.each {|instance| instances << instance} unless region_instances.nil?
     end
     task region.to_sym do
-      remove_default_roles
       instances.each do |instance|
         define_role(role, instance)
       end
@@ -273,7 +271,6 @@ Capistrano::Configuration.instance(:must_exist).load do
   def define_instance_roles(role, instances)
     instances.each do |instance|
       task instance.name.to_sym do
-        remove_default_roles
         define_role(role, instance)
       end
     end
@@ -281,7 +278,6 @@ Capistrano::Configuration.instance(:must_exist).load do
 
   def define_role_roles(role, instances)
     task role[:name].to_sym do
-      remove_default_roles
       instances.each do |instance|
         define_role(role, instance)
       end
@@ -320,10 +316,6 @@ Capistrano::Configuration.instance(:must_exist).load do
     else
         "#{singular}s"
     end
-  end
-
-  def remove_default_roles
-    roles.reject! { true }
   end
 
 end


### PR DESCRIPTION
When multiple roles are defined for the project chaining them wouldn't work as intended and only the latter role would be selected. This PR removes `remove_default_roles` method from capistrano hooks which seems to be irrelevant anymore unless I'm missing something obvious.
