### PR TITLE
fix load balancer regstration/de-registering within ec2 vpc

### DIFF
--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -161,7 +161,7 @@ class CapifyEc2
   end
 
   def get_instance_by_dns(dns)
-    desired_instances.select {|instance| instance.dns_name == dns}.first
+    desired_instances.select {|instance| instance.contact_point == dns}.first
   end
 
   def instance_health(load_balancer, instance)


### PR DESCRIPTION
rolling_deploy with load_balanced:true fails with:
[Capify-EC2] Deployment aborted due to error: undefined method `id' for nil:NilClass!
because no instances are found (the dns name doesn't match the IP address).
Changing to use instance.contact_point fixes this, and correctly registers/deregisters VPC instances.
