### PR TITLE
Add the ability to hint the rolling_deploy with a named ELB

### DIFF
--- a/capify-ec2.gemspec
+++ b/capify-ec2.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency('aws-sdk', '~> 3')
   s.add_dependency('colored', '=1.2')
   s.add_dependency('capistrano', '~> 2.14')
+  s.add_dependency('net-ssh', '=3.0.2')
 end

--- a/capify-ec2.gemspec
+++ b/capify-ec2.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_dependency('fog', '>= 1.23.0')
+  s.add_dependency('fog', '=1.23.0')
+  s.add_dependency('aws-sdk', '~> 3')
   s.add_dependency('colored', '=1.2')
   s.add_dependency('capistrano', '~> 2.14')
 end

--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -312,8 +312,8 @@ class CapifyEc2
     threads = []
 
     for load_balancer_name in load_balancer_names do
-      threads << Thread.new({
-        load_balancer = get_load_balancer_by_name(load_balancer_name)
+      threads << Thread.new(load_balancer_name) do |lb|
+        load_balancer = get_load_balancer_by_name(lb)
 
         if load_balancer
           puts "[Capify-EC2] Removing instance from named ELB '#{load_balancer.id}'..."
@@ -323,7 +323,7 @@ class CapifyEc2
 
           lbs << load_balancer
         end
-      })
+      end
     end
 
     for t in threads do

--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -309,17 +309,25 @@ class CapifyEc2
     instance = get_instance_by_dns(server_dns)
 
     lbs = []
+    threads = []
+
     for load_balancer_name in load_balancer_names do
-      load_balancer = get_load_balancer_by_name(load_balancer_name)
+      threads << Thread.new({
+        load_balancer = get_load_balancer_by_name(load_balancer_name)
 
-      if load_balancer
-        puts "[Capify-EC2] Removing instance from named ELB '#{load_balancer.id}'..."
+        if load_balancer
+          puts "[Capify-EC2] Removing instance from named ELB '#{load_balancer.id}'..."
 
-        result = elb.deregister_instances_from_load_balancer(instance.id, load_balancer.id)
-        raise "Unable to remove instance from ELB '#{load_balancer.id}'..." unless result.status == 200
+          result = elb.deregister_instances_from_load_balancer(instance.id, load_balancer.id)
+          raise "Unable to remove instance from ELB '#{load_balancer.id}'..." unless result.status == 200
 
-        lbs << load_balancer
-      end
+          lbs << load_balancer
+        end
+      })
+    end
+
+    for t in threads do
+      t.join
     end
 
     lbs

--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -306,6 +306,21 @@ class CapifyEc2
     end
   end
 
+  def deregister_instance_from_named_elb_by_dns(server_dns, load_balancer_name)
+    instance = get_instance_by_dns(server_dns)
+    load_balancer = get_load_balancer_by_name(load_balancer_name)
+
+    if load_balancer
+      puts "[Capify-EC2] Removing instance from named ELB '#{load_balancer.id}'..."
+
+      result = elb.deregister_instances_from_load_balancer(instance.id, load_balancer.id)
+      raise "Unable to remove instance from ELB '#{load_balancer.id}'..." unless result.status == 200
+
+      return load_balancer
+    end
+    false
+  end
+
   def deregister_instance_from_elb_by_dns(server_dns)
     instance = get_instance_by_dns(server_dns)
     load_balancer = get_load_balancer_by_instance(instance.id)

--- a/lib/capify-ec2.rb
+++ b/lib/capify-ec2.rb
@@ -266,7 +266,6 @@ class CapifyEc2
       lbs[load_balancer.id] = load_balancer
     end
     lbs[load_balancer_name]
-
   end
 
   def deregister_instance_from_elb(instance_name)
@@ -306,19 +305,24 @@ class CapifyEc2
     end
   end
 
-  def deregister_instance_from_named_elb_by_dns(server_dns, load_balancer_name)
+  def deregister_instance_from_named_elbs_by_dns(server_dns, load_balancer_names)
     instance = get_instance_by_dns(server_dns)
-    load_balancer = get_load_balancer_by_name(load_balancer_name)
 
-    if load_balancer
-      puts "[Capify-EC2] Removing instance from named ELB '#{load_balancer.id}'..."
+    lbs = []
+    for load_balancer_name in load_balancer_names do
+      load_balancer = get_load_balancer_by_name(load_balancer_name)
 
-      result = elb.deregister_instances_from_load_balancer(instance.id, load_balancer.id)
-      raise "Unable to remove instance from ELB '#{load_balancer.id}'..." unless result.status == 200
+      if load_balancer
+        puts "[Capify-EC2] Removing instance from named ELB '#{load_balancer.id}'..."
 
-      return load_balancer
+        result = elb.deregister_instances_from_load_balancer(instance.id, load_balancer.id)
+        raise "Unable to remove instance from ELB '#{load_balancer.id}'..." unless result.status == 200
+
+        lbs << load_balancer
+      end
     end
-    false
+
+    lbs
   end
 
   def deregister_instance_from_elb_by_dns(server_dns)
@@ -331,7 +335,11 @@ class CapifyEc2
       result = elb.deregister_instances_from_load_balancer(instance.id, load_balancer.id)
       raise "Unable to remove instance from ELB '#{load_balancer.id}'..." unless result.status == 200
 
-      return load_balancer
+      #TODO: The ability to remove an instance from multiple ELBs has been added, which returns an [] of elbs.
+      #I've taken a shortcut here to return an array for this (the single ELB case). However, the correct solution
+      #would be to extend the above method to remove an instance from multiple ELBs by DNS too.
+      #This may break things for some users however? Needs to be checked.
+      return [load_balancer]
     end
     false
   end

--- a/lib/capify-ec2/capistrano.rb
+++ b/lib/capify-ec2/capistrano.rb
@@ -121,7 +121,7 @@ Capistrano::Configuration.instance(:must_exist).load do
 
         roles.clear
 
-        load_balancers_to_reregister = nil # Set to nil again here, to ensure it always starts off nil for every iteration.
+        load_balancers_to_reregister = [] # Set to empty again here, to ensure it always starts off empty for every iteration.
         is_load_balanced = false
         load_balancer_names = false
 
@@ -174,7 +174,6 @@ Capistrano::Configuration.instance(:must_exist).load do
               end
             end
           end
-
         end
 
         for load_balancer_to_reregister in load_balancers_to_reregister do

--- a/lib/capify-ec2/capistrano.rb
+++ b/lib/capify-ec2/capistrano.rb
@@ -179,17 +179,17 @@ Capistrano::Configuration.instance(:must_exist).load do
         threads = []
 
         for load_balancer_to_reregister in load_balancers_to_reregister do
-          threads << Thread.new({
-            puts "[Capify-EC2] Starting registration of ELB '#{load_balancer_to_reregister.id}'"
+          threads << Thread.new(load_balancer_to_reregister) do |lb|
+            puts "[Capify-EC2] Starting registration of ELB '#{lb.id}'"
             
-            reregistered = capify_ec2.reregister_instance_with_elb_by_dns(server_dns, load_balancer_to_reregister, 60)
+            reregistered = capify_ec2.reregister_instance_with_elb_by_dns(server_dns, lb, 60)
             if reregistered
-              puts "[Capify-EC2] Instance registration with ELB '#{load_balancer_to_reregister.id}' successful.".green.bold
+              puts "[Capify-EC2] Instance registration with ELB '#{lb.id}' successful.".green.bold
             else
-              puts "[Capify-EC2] Instance registration with ELB '#{load_balancer_to_reregister.id}' failed!".red.bold
+              puts "[Capify-EC2] Instance registration with ELB '#{lb.id}' failed!".red.bold
               raise CapifyEC2RollingDeployError.new("ELB registration timeout exceeded", server_dns)
             end  
-          })
+          end
         end
 
         for t in threads do

--- a/lib/capify-ec2/capistrano.rb
+++ b/lib/capify-ec2/capistrano.rb
@@ -178,6 +178,7 @@ Capistrano::Configuration.instance(:must_exist).load do
         end
 
         for load_balancer_to_reregister in load_balancers_to_reregister do
+          puts "[Capify-EC2] Starting registration of ELB '#{load_balancer_to_reregister.id}'"
           reregistered = capify_ec2.reregister_instance_with_elb_by_dns(server_dns, load_balancer_to_reregister, 60)
           if reregistered
             puts "[Capify-EC2] Instance registration with ELB '#{load_balancer_to_reregister.id}' successful.".green.bold

--- a/readme.md
+++ b/readme.md
@@ -550,7 +550,20 @@ If an instance has been tagged with multiple roles, this behaviour will apply if
 
 If an instance is not associated with any ELBs, then the behaviour will be skipped silently, even if `:load_balanced` is set to 'true'.
 
+If an instance belongs to multiple ELBs, you can force which ELB is chosen by using the :elb_name parameter like this:
 
+```ruby
+ec2_roles :name => "web",
+          :variables => {
+            :healthcheck => {
+                :path   => '/status',
+                :port   => 80,
+                :result => 'OK'
+              }
+            :load_balanced => true,
+            :elb_name => "the_name_of_your_elb"
+          }
+```
 
 #### Viewing All Instances
 

--- a/readme.md
+++ b/readme.md
@@ -550,7 +550,7 @@ If an instance has been tagged with multiple roles, this behaviour will apply if
 
 If an instance is not associated with any ELBs, then the behaviour will be skipped silently, even if `:load_balanced` is set to 'true'.
 
-If an instance belongs to multiple ELBs, you can force which ELB is chosen by using the :elb_name parameter like this:
+If an instance belongs to multiple ELBs (e.g. a single instance pointed to by separate ELBs), you can force which ELBs are chosen by using the :elb_names parameter like this:
 
 ```ruby
 ec2_roles :name => "web",
@@ -561,7 +561,7 @@ ec2_roles :name => "web",
                 :result => 'OK'
               }
             :load_balanced => true,
-            :elb_name => "the_name_of_your_elb"
+            :elb_names => ["the_name_of_your_elb", "the_name_of_another_elb"]
           }
 ```
 


### PR DESCRIPTION
This resolves #63, allowing you to specific the name of the ELB to de-register from.

It does have at least one limitation which is if multiple roles are specified which belong to different ELBs it'll only use the last one.

I also haven't written ruby before - so please feel free to change it up if anything looks rubbish!
